### PR TITLE
Add missing registers to fix assertion errors in debug builds

### DIFF
--- a/src/core/sh2/peripherals/sh2_intc.cpp
+++ b/src/core/sh2/peripherals/sh2_intc.cpp
@@ -133,7 +133,7 @@ uint16_t read16(uint32_t addr)
 uint8_t read8(uint32_t addr)
 {
 	uint8_t result;
-	if((addr & 1) == 0)
+	if ((addr & 1) == 0)
 	{
 		// Read the first (high) byte
 		result = read16(addr) >> 8;
@@ -194,7 +194,7 @@ void write16(uint32_t addr, uint16_t value)
 void write8(uint32_t addr, uint8_t value)
 {
 	uint16_t tmp;
-	if((addr & 1) == 0)
+	if ((addr & 1) == 0)
 	{
 		// Write the first (high) byte by masking
 		tmp = read16(addr) & 0x00FF;

--- a/src/core/sh2/peripherals/sh2_intc.cpp
+++ b/src/core/sh2/peripherals/sh2_intc.cpp
@@ -80,12 +80,48 @@ uint16_t read16(uint32_t addr)
 
 	switch (addr)
 	{
+	case 0x04:
+	{
+		// IPRA
+		uint16_t result = state.prios[(int)IRQ::IRQ0] << 12;
+		result |= state.prios[(int)IRQ::IRQ1] << 8;
+		result |= state.prios[(int)IRQ::IRQ2] << 4;
+		result |= state.prios[(int)IRQ::IRQ3];
+		return result;
+	}
+	case 0x06:
+	{
+		// IPRB
+		uint16_t result = state.prios[(int)IRQ::IRQ4] << 12;
+		result |= state.prios[(int)IRQ::IRQ5] << 8;
+		result |= state.prios[(int)IRQ::IRQ6] << 4;
+		result |= state.prios[(int)IRQ::IRQ7];
+		return result;
+	}
 	case 0x08:
 	{
-		uint16_t result = state.prios[(int)IRQ::ITU1];
-		result |= state.prios[(int)IRQ::ITU0] << 4;
+		// IPRC
+		uint16_t result =  state.prios[(int)IRQ::DMAC0] << 12;
 		result |= state.prios[(int)IRQ::DMAC2] << 8;
-		result |= state.prios[(int)IRQ::DMAC0] << 12;
+		result |= state.prios[(int)IRQ::ITU0] << 4;
+		result |= state.prios[(int)IRQ::ITU1];
+		return result;
+	}
+	case 0x0A:
+	{
+		// IPRD
+		uint16_t result = state.prios[(int)IRQ::ITU2] << 12;
+		result |= state.prios[(int)IRQ::ITU3] << 8;
+		result |= state.prios[(int)IRQ::ITU4] << 4;
+		result |= state.prios[(int)IRQ::SCI0];
+		return result;
+	}
+	case 0x0C:
+	{
+		// IPRE
+		uint16_t result = state.prios[(int)IRQ::SCI1] << 12;
+		result |= state.prios[(int)IRQ::PRT] << 8;
+		result |= state.prios[(int)IRQ::WDT] << 4;
 		return result;
 	}
 	default:
@@ -96,26 +132,18 @@ uint16_t read16(uint32_t addr)
 
 uint8_t read8(uint32_t addr)
 {
-	addr &= 0xF;
-
-	switch (addr)
+	uint8_t result;
+	if((addr & 1) == 0)
 	{
-	case 0x08:
+		// Read the first (high) byte
+		result = read16(addr) >> 8;
+	}
+	else
 	{
-		uint8_t result = state.prios[(int)IRQ::DMAC2];
-		result |= state.prios[(int)IRQ::DMAC0] << 4;
-		return result;
+		// Read the second (low) byte
+		result = read16(addr - 1) & 0xFF;
 	}
-	case 0x09:
-	{
-		uint8_t result = state.prios[(int)IRQ::ITU1];
-		result |= state.prios[(int)IRQ::ITU0] << 4;
-		return result;
-	}
-	default:
-		assert(0);
-		return 0;
-	}
+	return result;
 }
 
 void write16(uint32_t addr, uint16_t value)
@@ -124,11 +152,39 @@ void write16(uint32_t addr, uint16_t value)
 
 	switch (addr)
 	{
+	case 0x04:
+		// IPRA
+		state.prios[(int)IRQ::IRQ0] = value >> 12;
+		state.prios[(int)IRQ::IRQ1] = (value >> 8) & 0x0F;
+		state.prios[(int)IRQ::IRQ2] = (value >> 4) & 0x0F;
+		state.prios[(int)IRQ::IRQ3] = value & 0x0F;
+		break;
+	case 0x06:
+		// IPRB
+		state.prios[(int)IRQ::IRQ4] = value >> 12;
+		state.prios[(int)IRQ::IRQ5] = (value >> 8) & 0x0F;
+		state.prios[(int)IRQ::IRQ6] = (value >> 4) & 0x0F;
+		state.prios[(int)IRQ::IRQ7] = value & 0x0F;
+		break;
 	case 0x08:
-		state.prios[(int)IRQ::ITU1] = value & 0x0F;
-		state.prios[(int)IRQ::ITU0] = (value >> 4) & 0x0F;
-		state.prios[(int)IRQ::DMAC2] = state.prios[(int)IRQ::DMAC3] = (value >> 8) & 0x0F;
+		// IPRC
 		state.prios[(int)IRQ::DMAC0] = state.prios[(int)IRQ::DMAC1] = value >> 12;
+		state.prios[(int)IRQ::DMAC2] = state.prios[(int)IRQ::DMAC3] = (value >> 8) & 0x0F;
+		state.prios[(int)IRQ::ITU0] = (value >> 4) & 0x0F;
+		state.prios[(int)IRQ::ITU1] = value & 0x0F;
+		break;
+	case 0x0A:
+		// IPRD
+		state.prios[(int)IRQ::ITU2] = value >> 12;
+		state.prios[(int)IRQ::ITU3] = (value >> 8) & 0x0F;
+		state.prios[(int)IRQ::ITU4] = (value >> 4) & 0x0F;
+		state.prios[(int)IRQ::SCI0] = value & 0x0F;
+		break;
+	case 0x0C:
+		// IPRE
+		state.prios[(int)IRQ::SCI1] = value >> 12;
+		state.prios[(int)IRQ::PRT] = (value >> 8) & 0x0F;
+		state.prios[(int)IRQ::WDT] = state.prios[(int)IRQ::REF] = (value >> 4) & 0x0F;
 		break;
 	default:
 		assert(0);
@@ -137,20 +193,20 @@ void write16(uint32_t addr, uint16_t value)
 
 void write8(uint32_t addr, uint8_t value)
 {
-	addr &= 0xF;
-
-	switch (addr)
+	uint16_t tmp;
+	if((addr & 1) == 0)
 	{
-	case 0x08:
-		state.prios[(int)IRQ::DMAC2] = state.prios[(int)IRQ::DMAC3] = value & 0x0F;
-		state.prios[(int)IRQ::DMAC0] = state.prios[(int)IRQ::DMAC1] = value >> 4;
-		break;
-	case 0x09:
-		state.prios[(int)IRQ::ITU1] = value & 0x0F;
-		state.prios[(int)IRQ::ITU0] = value >> 4;
-		break;
-	default:
-		assert(0);
+		// Write the first (high) byte by masking
+		tmp = read16(addr) & 0x00FF;
+		tmp |= value << 8;
+		write16(addr, tmp);
+	}
+	else
+	{
+		// Write the second (low) byte by masking
+		tmp = read16(addr - 1) & 0xFF00;
+		tmp |= value;
+		write16(addr - 1, tmp);
 	}
 }
 

--- a/src/core/sh2/peripherals/sh2_timers.cpp
+++ b/src/core/sh2/peripherals/sh2_timers.cpp
@@ -126,6 +126,16 @@ static void update_timer_irq(Timer* timer)
 	}
 }
 
+static void update_timer_target(Timer* timer)
+{
+	// Disable and re-enable to force new timing to take effect
+	if (timer->enabled)
+	{
+		timer->set_enable(false);
+		timer->set_enable(true);
+	}
+}
+
 static void intr_event(uint64_t param, int cycles_late)
 {
 	assert(!cycles_late);
@@ -267,9 +277,11 @@ void write8(uint32_t addr, uint8_t value)
 		{
 		case 0x00:
 			printf("[Timer] write timer%d ctrl: %02X\n", timer->id, value);
+			timer->update_counter();
 			timer->ctrl.clock = value & 0x7;
 			timer->ctrl.edge_mode = (value >> 3) & 0x3;
 			timer->ctrl.clear_mode = (value >> 5) & 0x3;
+			update_timer_target(timer);
 			break;
 		case 0x01:
 			printf("[Timer] write timer%d io ctrl: %02X\n", timer->id, value);
@@ -278,6 +290,7 @@ void write8(uint32_t addr, uint8_t value)
 		case 0x02:
 			printf("[Timer] write timer%d intr enable: %02X\n", timer->id, value);
 			timer->intr_enable = value;
+			update_timer_irq(timer);
 			break;
 		case 0x03:
 			printf("[Timer] write timer%d intr flag: %02X\n", timer->id, value);
@@ -287,13 +300,17 @@ void write8(uint32_t addr, uint8_t value)
 		case 0x04:
 			printf("[Timer] write timer%d counter: %02X**\n", timer->id, value);
 			//The BIOS writes 0 to here under the assumption that it resets the whole counter...
+			timer->update_counter();
 			timer->counter &= 0x00FF;
 			timer->counter |= value << 8;
+			update_timer_target(timer);
 			break;
 		case 0x05:
 			printf("[Timer] write timer%d counter: **%02X\n", timer->id, value);
+			timer->update_counter();
 			timer->counter &= 0xFF00;
 			timer->counter |= value;
+			update_timer_target(timer);
 			break;
 		default:
 			assert(0);
@@ -342,11 +359,14 @@ void write16(uint32_t addr, uint16_t value)
 		case 0x04:
 			printf("[Timer] write timer%d counter: %04X\n", timer->id, value);
 			timer->counter = value;
+			update_timer_target(timer);
 		case 0x06:
 		case 0x08:
 			reg = (reg - 0x06) >> 1;
 			printf("[Timer] write timer%d general reg%d: %04X\n", timer->id, reg, value);
+			timer->update_counter();
 			timer->gen_reg[reg] = value;
+			update_timer_target(timer);
 			break;
 		default:
 			assert(0);

--- a/src/core/sh2/peripherals/sh2_timers.cpp
+++ b/src/core/sh2/peripherals/sh2_timers.cpp
@@ -285,11 +285,15 @@ void write8(uint32_t addr, uint8_t value)
 			update_timer_irq(timer);
 			break;
 		case 0x04:
-			printf("[Timer] write timer%d counter: %02X\n", timer->id, value);
-
+			printf("[Timer] write timer%d counter: %02X**\n", timer->id, value);
 			//The BIOS writes 0 to here under the assumption that it resets the whole counter...
-			assert(!value);
-			timer->counter = 0;
+			timer->counter &= 0x00FF;
+			timer->counter |= value << 8;
+			break;
+		case 0x05:
+			printf("[Timer] write timer%d counter: **%02X\n", timer->id, value);
+			timer->counter &= 0xFF00;
+			timer->counter |= value;
 			break;
 		default:
 			assert(0);
@@ -335,6 +339,9 @@ void write16(uint32_t addr, uint16_t value)
 	{
 		switch (reg)
 		{
+		case 0x04:
+			printf("[Timer] write timer%d counter: %04X\n", timer->id, value);
+			timer->counter = value;
 		case 0x06:
 		case 0x08:
 			reg = (reg - 0x06) >> 1;

--- a/src/core/sh2/peripherals/sh2_timers.cpp
+++ b/src/core/sh2/peripherals/sh2_timers.cpp
@@ -360,6 +360,7 @@ void write16(uint32_t addr, uint16_t value)
 			printf("[Timer] write timer%d counter: %04X\n", timer->id, value);
 			timer->counter = value;
 			update_timer_target(timer);
+			break;
 		case 0x06:
 		case 0x08:
 			reg = (reg - 0x06) >> 1;


### PR DESCRIPTION
Non critical, causes abort in debug builds for several games but does not affect release builds.

Summary of changes:
- Implement missing write16 and lower-half write8 for timer TCNT
- Implement missing reads/writes for all IPRx registers to corresponding priorities (unimplemented IRQs included)
- Refactor IPRx read8/write8 to use local read16/write16 with masking (code deduplication)
- Sync and refresh timers' timing when changing registers it is affected by (followed from TCNT fix)
